### PR TITLE
Performance improvements again

### DIFF
--- a/met_explore/peak_selection.py
+++ b/met_explore/peak_selection.py
@@ -837,8 +837,6 @@ class PeakSelector(object):
         :param rt: The retention time of the peak
         :return: duplicates - A boolean stating whether or not the peak_df contains duplicates for this given (mz,rt) peak.
         """
-        duplicates = False
-
         mass_tol = mz * MASS_PPM * PPM
         min_mass = mz - mass_tol
         max_mass = mz + mass_tol
@@ -846,9 +844,11 @@ class PeakSelector(object):
         min_rt = rt - RT_TOL
         max_rt = rt + RT_TOL
 
-        for index, row in peak_df.iterrows():
-            # If the mz and RT lie within a value then there are duplicates in the dataframe
-            if (min_mass < row.mass < max_mass) and (min_rt < row.rt < max_rt):
-                duplicates = True
+        min_mass_check = min_mass < peak_df['mass'].values
+        max_mass_check = peak_df['mass'].values < max_mass
+        min_rt_check = min_rt < peak_df['rt'].values
+        max_rt_check = peak_df['rt'].values < max_rt
+        dupe_idx = np.nonzero(min_mass_check & max_mass_check & min_rt_check & max_rt_check)[0]
 
+        duplicates = True if len(dupe_idx) > 0 else False
         return duplicates

--- a/met_explore/peak_selection.py
+++ b/met_explore/peak_selection.py
@@ -134,8 +134,8 @@ class PeakSelector(object):
         except FileNotFoundError:
 
             headers = list(all_peaks.columns.values)
-            all_peak_df = pd.DataFrame(columns=headers)
             all_unique_sec_ids = all_peaks['sec_id'].unique()
+            all_rows = []
 
             # For each unique peak based on pimp Sec_id
             for sid in tqdm(all_unique_sec_ids):
@@ -146,8 +146,9 @@ class PeakSelector(object):
                 # For each of the unique compounds add a row to the DF
                 for cmpd_id in unique_cmpd_ids:
                     new_row = self.get_peak_by_cmpd_id(sid_df, cmpd_id)
-                    all_peak_df = all_peak_df.append(new_row)
+                    all_rows.append(new_row)
 
+            all_peak_df = pd.DataFrame(all_rows, columns=headers)
             try:
                 all_peak_df.to_pickle("./data/" + PEAK_FILE_NAME + ".pkl")
             except Exception as e:

--- a/met_explore/population_scripts.py
+++ b/met_explore/population_scripts.py
@@ -148,17 +148,20 @@ def populate_peaksamples(intensity_df, pids_sids_dict):
 
         # Get the data for the SamplePeak
         # for index, value in this_col.iteritems():
+        data = []
         for index, value in tqdm(this_col.iteritems(), total=this_col.shape[0]):
             sec_id = pids_sids_dict[index]
             intensity = value
             peak = Peak.objects.get(psec_id=sec_id)
             logger.debug("we are adding the data for: %s %s %f " % (sample, peak, intensity))
 
-            # Populate the DB
-            samplepeak_serializer = SamplePeakSerializer(
-                data={"peak": peak.id, "sample": sample.id, "intensity": intensity})
-            if samplepeak_serializer.is_valid():
-                db_samplepeak = samplepeak_serializer.save()
-                logger.debug("peak saved %s" % db_samplepeak.peak)
-            else:
-                logger.warning(samplepeak_serializer.errors)
+            record = {"peak": peak.id, "sample": sample.id, "intensity": intensity}
+            data.append(record)
+
+        # Populate the DB
+        samplepeak_serializer = SamplePeakSerializer(data=data, many=True)
+        if samplepeak_serializer.is_valid():
+            samplepeak_serializer.save()
+            logger.debug("peak saved")
+        else:
+            logger.warning(samplepeak_serializer.errors)

--- a/met_explore/preprocessing.py
+++ b/met_explore/preprocessing.py
@@ -117,19 +117,28 @@ class PreprocessCompounds(object):
 
             ## Add Chebi names, smile and cas-codes to the peak DF
             logger.info("Adding Chebi names, smile and cas-codes to the peak DF")
+            new_chebi_names = []
+            new_cas_codes = []
+            new_smiles = []
             for index, row in tqdm(self.peak_df.iterrows(), total=self.peak_df.shape[0]):
                 if row.chebi_id:  # If not a null value
                     chebi_id = row.chebi_id
-                    chebi_name = self.chebi_df[self.chebi_df.chebi_id == chebi_id].chebi_name.values[
-                        0]
-                    smiles = self.chebi_df[self.chebi_df.chebi_id == chebi_id].smiles.values[
-                        0]
-                    cas_code = self.chebi_df[self.chebi_df.chebi_id == chebi_id].cas_code.values[
-                        0]
+                    chebi_name = temp_dict['cas_code'][chebi_id]
+                    smiles = temp_dict['chebi_name'][chebi_id]
+                    cas_code = temp_dict['smiles'][chebi_id]
                     logger.debug('%s %s' % (chebi_id, chebi_name))
-                    self.peak_df.loc[index, 'chebi_name'] = chebi_name
-                    self.peak_df.loc[index, 'cas_code'] = cas_code
-                    self.peak_df.loc[index, 'smiles'] = smiles
+                else:
+                    chebi_name = None
+                    smiles = None
+                    cas_code = None
+
+                new_chebi_names.append(chebi_name)
+                new_cas_codes.append(cas_code)
+                new_smiles.append(smiles)
+
+            self.peak_df['chebi_name'] = chebi_name
+            self.peak_df['cas_code'] = cas_code
+            self.peak_df['smiles'] = smiles
 
             try:
                 logger.info("Saving peak DF")

--- a/met_explore/preprocessing.py
+++ b/met_explore/preprocessing.py
@@ -96,8 +96,8 @@ class PreprocessCompounds(object):
                             new_inchikeys.append(set_inchi) # unchanged?
 
                 else: # chebi id has been set, don't change it
-                    new_chebi_ids(set_chebi_id)
-                    new_inchikeys(set_inchi)
+                    new_chebi_ids.append(set_chebi_id)
+                    new_inchikeys.append(set_inchi)
 
             self.peak_df['chebi_id'] = new_chebi_ids
             self.peak_df['inchikey'] = new_inchikeys
@@ -107,6 +107,10 @@ class PreprocessCompounds(object):
             new_chebi_names = []
             new_cas_codes = []
             new_smiles = []
+            chebi_name = None
+            smiles = None
+            cas_code = None
+
             for index, row in tqdm(self.peak_df.iterrows(), total=self.peak_df.shape[0]):
                 if row.chebi_id:  # If not a null value
                     chebi_id = row.chebi_id
@@ -114,10 +118,6 @@ class PreprocessCompounds(object):
                     smiles = temp_dict['chebi_name'][chebi_id]
                     cas_code = temp_dict['smiles'][chebi_id]
                     logger.debug('%s %s' % (chebi_id, chebi_name))
-                else:
-                    chebi_name = None
-                    smiles = None
-                    cas_code = None
 
                 new_chebi_names.append(chebi_name)
                 new_cas_codes.append(cas_code)


### PR DESCRIPTION
A number of improvements to make the pipeline faster:

1. When populating the DB with `SamplePeakSerializer`, we use `many=True` allowing us to do a bulk insert of many records.
2. Using dictionary lookup if possible, rather than searching in the chebi dataframe using e.g. `self.chebi_df[self.chebi_df.chebi_id == chebi_id]` which can be slow.
3. Not modifying the peakdf when we're looping over it. Instead we set the new values all at once in the end. This should help with performance too.
4. Don't append to an empty dataframe. Instead we create it in the end.
5. Vectorised duplicate checks rather than using loops.